### PR TITLE
Introduce -D_GLIBCXX_USE_C99_STDLIB switch that compiles sdsl-lite

### DIFF
--- a/sdsl-lite-git.patch
+++ b/sdsl-lite-git.patch
@@ -1,0 +1,63 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 657949f..fcedbee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,7 +44,7 @@ else()
+ endif()
+ 
+ if( CMAKE_COMPILER_IS_GNUCXX )
+-    append_cxx_compiler_flags("-std=c++11 -Wall -Wextra -DNDEBUG" "GCC" CMAKE_CXX_FLAGS)
++    append_cxx_compiler_flags("-std=c++11 -D_GLIBCXX_USE_C99_STDLIB -Wall -Wextra -DNDEBUG" "GCC" CMAKE_CXX_FLAGS)
+     append_cxx_compiler_flags("-O3 -ffast-math -funroll-loops" "GCC" CMAKE_CXX_OPT_FLAGS)
+     if ( CODE_COVERAGE )
+         append_cxx_compiler_flags("-g -fprofile-arcs -ftest-coverage -lgcov" "GCC" CMAKE_CXX_FLAGS)
+@@ -118,7 +118,6 @@ else()
+     message(WARNING "git not found. Cloning of submodules will not work.")
+ endif()
+ 
+-add_subdirectory(external)
+ add_subdirectory(include)
+ add_subdirectory(lib)
+ 
+diff --git a/include/sdsl/CMakeLists.txt b/include/sdsl/CMakeLists.txt
+index ef921f0..525aff4 100644
+--- a/include/sdsl/CMakeLists.txt
++++ b/include/sdsl/CMakeLists.txt
+@@ -11,7 +11,7 @@ file(GLOB hppFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_
+ 
+ foreach(hppFile ${hppFiles}) # copy each file
+ 	configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/${hppFile}" "${CMAKE_CURRENT_BINARY_DIR}/${hppFile}" COPYONLY ) 
+-	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${hppFile}" DESTINATION include/sdsl)
++  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${hppFile}" DESTINATION "include")
+ #	MESSAGE(${hppFile})
+ endforeach(hppFile)
+ 
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index b2e606e..ea78ba9 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -1,6 +1,5 @@
+ include_directories(#"${CMAKE_CURRENT_SOURCE_DIR}/../include"
+         "${CMAKE_CURRENT_BINARY_DIR}/../include"
+-        "${CMAKE_CURRENT_BINARY_DIR}/../external/libdivsufsort/include"
+         )
+ 
+ 
+@@ -11,12 +10,14 @@ endif()
+ 
+ set( sdsl_SRCS ${libFiles} ${headerFiles})
+ 
+-add_library( sdsl ${sdsl_SRCS} )
++add_library( sdsl_static ${sdsl_SRCS} )
++add_library( sdsl SHARED ${sdsl_SRCS} )
++
+ 
+ install(TARGETS sdsl
+         RUNTIME DESTINATION bin
+-        LIBRARY DESTINATION lib
+-        ARCHIVE DESTINATION lib)
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+         
+ math(EXPR SOVERSION "${LIBRARY_VERSION_MAJOR}+1")
+ 

--- a/seqwish.patch
+++ b/seqwish.patch
@@ -1,0 +1,59 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1998679..ff2a31c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@ find_package(Threads REQUIRED)
+ 
+ # Use all standard-compliant optimizations
+ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -g")
+-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -g")
++set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -g -D_GLIBCXX_USE_C99_STDLIB")
+ 
+ # Set the output folder where your program will be created
+ set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+@@ -26,16 +26,16 @@ include_directories("${PROJECT_SOURCE_DIR}")
+ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+ 
+ # sdsl-lite (full build using its cmake config)
+-ExternalProject_Add(sdsl-lite
+-  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/sdsl-lite"
+-  CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>"
+-  UPDATE_COMMAND ""
+-  INSTALL_COMMAND "")
+-ExternalProject_Get_property(sdsl-lite INSTALL_DIR)
+-set(sdsl-lite_INCLUDE "${INSTALL_DIR}/src/sdsl-lite-build/include")
+-set(sdsl-lite-divsufsort_INCLUDE "${INSTALL_DIR}/src/sdsl-lite-build/external/libdivsufsort/include")
+-set(sdsl-lite_LIB "${INSTALL_DIR}/src/sdsl-lite-build/lib")
+-set(sdsl-lite-divsufsort_LIB "${INSTALL_DIR}/src/sdsl-lite-build/external/libdivsufsort/lib")
++# ExternalProject_Add(sdsl-lite
++#  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/sdsl-lite"
++#  CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>"
++#  UPDATE_COMMAND ""
++#  INSTALL_COMMAND "")
++#ExternalProject_Get_property(sdsl-lite INSTALL_DIR)
++#set(sdsl-lite_INCLUDE "${INSTALL_DIR}/src/sdsl-lite-build/include")
++#set(sdsl-lite-divsufsort_INCLUDE "${INSTALL_DIR}/src/sdsl-lite-build/external/libdivsufsort/include")
++#set(sdsl-lite_LIB "${INSTALL_DIR}/src/sdsl-lite-build/lib")
++#set(sdsl-lite-divsufsort_LIB "${INSTALL_DIR}/src/sdsl-lite-build/external/libdivsufsort/lib")
+ 
+ # taywee's C++ args library, header only
+ ExternalProject_Add(tayweeargs
+@@ -166,7 +166,6 @@ add_executable(seqwish
+   ${CMAKE_SOURCE_DIR}/src/mmap.cpp
+   )
+ add_dependencies(seqwish tayweeargs)
+-add_dependencies(seqwish sdsl-lite)
+ add_dependencies(seqwish gzipreader)
+ add_dependencies(seqwish mmmulti)
+ add_dependencies(seqwish iitii)
+@@ -178,8 +177,8 @@ add_dependencies(seqwish atomicqueue)
+ add_dependencies(seqwish ska)
+ add_dependencies(seqwish paryfor)
+ target_include_directories(seqwish PUBLIC
+-  "${sdsl-lite_INCLUDE}"
+-  "${sdsl-lite-divsufsort_INCLUDE}"
++  # "${sdsl-lite_INCLUDE}"
++  # "${sdsl-lite-divsufsort_INCLUDE}"
+   "${tayweeargs_INCLUDE}"
+   "${gzipreader_INCLUDE}"
+   "${ips4o_INCLUDE}"

--- a/seqwish.scm
+++ b/seqwish.scm
@@ -1,15 +1,67 @@
 (define-module (seqwish)
   #:use-module (guix packages)
   #:use-module (guix git-download)
+  #:use-module (guix download)
   #:use-module (guix build-system cmake)
   #:use-module ((guix licenses) #:prefix license:)
+  #:use-module (gnu packages)
   #:use-module (gnu packages base)
+  #:use-module (gnu packages datastructures)
+  #:use-module (gnu packages documentation)
   #:use-module (gnu packages gcc)
+  #:use-module (gnu packages graphviz)
   #:use-module (gnu packages cmake)
   #:use-module (gnu packages python)
   #:use-module (gnu packages wget)
   #:use-module (gnu packages bash)
   #:use-module (gnu packages compression))
+
+(define-public sdsl-lite-git
+  (let ((commit "c32874cb2d8524119f25f3b501526fe692df29f4"))
+   (package
+    (name "sdsl-lite-git")
+    (version (string-append "2.1.2-pre-" (string-take commit 7)))
+    (source (origin
+               (method git-fetch)
+                (uri (git-reference
+                 (url "https://github.com/simongog/sdsl-lite.git") 
+                 (commit commit))) 
+                 (file-name (string-append name "-" version "-checkout"))
+                 (sha256
+                  (base32
+                    "1p53cgrgkp72s0mx262pxz90mf04vy4c1189xlx146qh8fznywg4"))
+                (modules '((guix build utils)))
+                (snippet
+                 '(begin
+                  (delete-file-recursively "external") #t))
+                (patches (list
+                   (search-patch "sdsl-lite-git.patch")))))
+    (build-system cmake-build-system)
+    (arguments
+     '(#:phases
+       (modify-phases %standard-phases
+         (add-after 'install 'install-static-library
+           (lambda* (#:key outputs #:allow-other-keys)
+             (let ((out (assoc-ref outputs "out")))
+               (copy-file "lib/libsdsl_static.a"
+                          (string-append out "/lib/libsdsl.a")))
+             #t)))))
+    (inputs
+     `(("doxygen" ,doxygen)
+       ("graphviz" ,graphviz)))
+    (native-inputs                                                                                         
+     `(("libdivsufsort" ,libdivsufsort)))
+    (home-page "https://github.com/simongog/sdsl-lite")
+    (synopsis "Succinct data structure library")
+    (description "The Succinct Data Structure Library (SDSL) is a powerful and
+flexible C++11 library implementing succinct data structures.  In total, the
+library contains the highlights of 40 research publications.  Succinct data
+structures can represent an object (such as a bitvector or a tree) in space       
+close to the information-theoretic lower bound of the object while supporting     
+operations of the original object efficiently.  The theoretical time              
+complexity of an operation performed on the classical data structure and the      
+equivalent succinct data structure are (most of the time) identical.")            
+    (license license:gpl3+))))
 
 (define-public seqwish
   (let ((version "0.6.0")
@@ -27,15 +79,19 @@
               (file-name (git-file-name name version))
               (sha256
                (base32
-                "1g3k0bbdfnbap2xw27js2yc2xqs96vxarmmg2hv0zx62hfjkz7lx"))))
+                "1g3k0bbdfnbap2xw27js2yc2xqs96vxarmmg2hv0zx62hfjkz7lx"))
+              (patches (list
+                 (search-patch "seqwish.patch")))))
      (build-system cmake-build-system)
      (arguments
       `(#:phases
         (modify-phases
          %standard-phases
          (delete 'check))))
+     (inputs
+      `(("sdsl-lite-git" ,sdsl-lite-git)))
      (native-inputs
-      `(("gcc" ,gcc-9)
+      `(("gcc" ,gcc)
         ("cmake" ,cmake)
         ("zlib" ,zlib)))
      (synopsis "variation graph inducer")


### PR DESCRIPTION
on gcc8 and later on GNU Guix. The seqwish build still fails with 

```
make[4]: *** [CMakeFiles/Makefile2:111: CMakeFiles/argstest.dir/all] Error 2
make[4]: Leaving directory '/tmp/guix-build-seqwish-0.6.0+3680d31-1.drv-0/build/tayweeargs-prefix/src/tayweeargs-build'
make[3]: *** [Makefile:141: all] Error 2
make[3]: Leaving directory '/tmp/guix-build-seqwish-0.6.0+3680d31-1.drv-0/build/tayweeargs-prefix/src/tayweeargs-build'
make[2]: *** [CMakeFiles/tayweeargs.dir/build.make:115: tayweeargs-prefix/src/tayweeargs-stamp/tayweeargs-build] Error 2
```

but as that is a different problem I leave that to @ekg. Better package that separately too or maybe drop it since 'args' is no longer maintained.