### PR TITLE
Add mashz (and mashz-lastz) to guix

### DIFF
--- a/mashz.scm
+++ b/mashz.scm
@@ -1,0 +1,52 @@
+(define-module (mashz)
+  #:use-module (guix packages)
+  #:use-module (guix git-download)
+  #:use-module (guix build-system cmake)
+  #:use-module ((guix licenses) #:prefix license:)
+  #:use-module (gnu packages)
+  #:use-module (gnu packages base)
+  #:use-module (gnu packages crypto)
+  #:use-module (gnu packages gcc)
+  #:use-module (gnu packages cmake)
+  #:use-module (gnu packages tls)
+  #:use-module (gnu packages python)
+  #:use-module (gnu packages curl)
+  #:use-module (gnu packages bash)
+  #:use-module (gnu packages maths)
+  #:use-module (gnu packages autotools)
+  #:use-module (gnu packages compression))
+
+(define-public mashz
+  (let ((version "0.0.1")
+        (commit "085e43da5aaad2e62708758311d465048c9c423c")
+        (package-revision "1"))
+    (package
+     (name "mashz")
+     (version (string-append version "+" (string-take commit 7) "-" package-revision))
+     (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/urbanslug/mashz.git")
+                    (commit commit)
+                    (recursive? #f)))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32
+                "0z6j20rd9bbp9xwxwmnvn3zsmrm428s0hrcdkzbfyv98s678x85l"))))
+     (build-system cmake-build-system)
+     (arguments
+      `(#:phases
+        (modify-phases
+         %standard-phases
+         (delete 'check))
+        ;;#:configure-flags '("-DBUILD_TESTING=false")
+        #:make-flags (list "CC=gcc CXX=g++")))
+     (native-inputs
+      `(("cmake" ,cmake)
+        ("gsl" ,gsl)
+        ("gcc" ,gcc-10)
+        ("zlib" ,zlib)))
+     (synopsis "base-accurate DNA sequence alignments using lastz and mashmap2")
+     (description "mashz uses mashmap to perform approximate matching to somewhat roughly identify similar regions and then runs lastz over these regions to performs base level alignment and get a more accurate alignment.")
+     (home-page "https://github.com/urbanslug/mashz")
+     (license license:expat))))


### PR DESCRIPTION
This mashz install also installs mashz-lastz which it depends on for base level alignment.